### PR TITLE
Get Product by Product/index

### DIFF
--- a/types/index.go
+++ b/types/index.go
@@ -131,3 +131,8 @@ func ExpireCache() error {
 	}
 	return nil
 }
+
+func BustCache() error {
+	CacheMaxAge = 0
+	return ExpireCache()
+}

--- a/types/index.go
+++ b/types/index.go
@@ -24,7 +24,8 @@ type Index struct {
 func NewIndex(indexURL string) (Index, error) {
 	var index Index
 
-	b, err := GetIndexBody(indexURL, true)
+	cacheIndex := true
+	b, err := GetIndexBody(indexURL, cacheIndex)
 	if err != nil {
 		return index, err
 	}

--- a/types/product.go
+++ b/types/product.go
@@ -22,12 +22,10 @@ type Product struct {
 func NewProduct(indexURL string) (*Product, error) {
 	var product Product
 
-	_ = BustCache()
-	b, err := GetIndexBody(indexURL)
+	b, err := GetIndexBody(indexURL, false)
 	if err != nil {
 		return &product, err
 	}
-	_ = BustCache()
 	if err = json.Unmarshal(b, &product); err != nil {
 		return &product, err
 	}

--- a/types/product.go
+++ b/types/product.go
@@ -22,7 +22,8 @@ type Product struct {
 func NewProduct(indexURL string) (*Product, error) {
 	var product Product
 
-	b, err := GetIndexBody(indexURL, false)
+	cacheIndex := false
+	b, err := GetIndexBody(indexURL, cacheIndex)
 	if err != nil {
 		return &product, err
 	}


### PR DESCRIPTION
This lets the module get the Product by {product}/index.json rather than the root index.json.

For comparison, for consul, this json is 357kb vs 11mb.
Context of usage: https://github.com/hashicorp/linux-packaging/commit/54146ff857450fd49d865f89d699bedf1712cacc#diff-6979b23d6bc4f8302a567ed5f4b7f78aL86-L90

I added the bust cache before/after. It feels a bit dirty.. I'm fine with reworking the `GetIndexBody` to do the get separate from the caching instead if you'd prefer it that way, let me know!